### PR TITLE
add health check endpoint

### DIFF
--- a/lib/web_api.ex
+++ b/lib/web_api.ex
@@ -66,6 +66,16 @@ defmodule WebApi do
     end
   end
 
+  get "/_health" do
+    send_resp(conn, 200, "")
+  end
+
+  match _ do
+    send_resp(conn, 404, "Not found")
+  end
+
+  defp enforce_api_key(%Plug.Conn{path_info: ["_health"]} = conn, _opts), do: conn
+
   defp enforce_api_key(conn, _opts) do
     api_key =
       Enum.find_value(conn.req_headers, fn {key, value} -> if(key == "x-api-key", do: value) end)


### PR DESCRIPTION
This adds a health check endpoint, which will be used by the load balancer. Also adds a catch-all 404 route.