### PR TITLE
feat: use shared MBTA lexicon

### DIFF
--- a/lib/web_api.ex
+++ b/lib/web_api.ex
@@ -36,6 +36,7 @@ defmodule WebApi do
           ExAws.Polly.synthesize_speech(text,
             voice_id: voice_id,
             engine: "neural",
+            lexicon_names: ["mbtalexicon"],
             text_type: "ssml",
             output_format: "mp3"
           )


### PR DESCRIPTION
See [📦 lexicon-examples.zip](https://github.com/user-attachments/files/16628110/lexicon-examples.zip) for two example files synthesized before and after this change. Both read _"The next train to Lechmere is now arriving."_ in the `Matthew` voice. "Lechmere" is [given a custom pronunciation](https://github.com/mbta/devops/blob/2a90ca1/aws-polly-lexicon/mbtalexicon.pls#L9) in our lexicon.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207891567618361