### PR TITLE
Improve dev documentation

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -8,7 +8,7 @@
 # export WATTS_API_KEY=
 
 # Bucket to use for caching audio files. Required.
-export WATTS_BUCKET=mbta-audio-service-test
+export WATTS_BUCKET=mbta-watts-staging
 
 # AWS credentials. Required.
 # export AWS_ACCESS_KEY_ID=

--- a/README.md
+++ b/README.md
@@ -11,5 +11,27 @@ MBTA text-to-speech service
 
 * Run `asdf install` from the repository root.
 * `mix deps.get` to fetch dependencies.
-* Copy `.envrc.template` to `.envrc`, then edit `.envrc` and make sure all required environment variables are set. When finished, run `direnv allow` to activate them.
+* Copy `.envrc.template` to `.envrc`, then edit `.envrc` and make sure all
+  required environment variables are set. When finished, run `direnv allow` to
+  activate them.
 * To start the server, run `iex -S mix`.
+
+**Note:** There is no automatic code reloading in development. To pick up code
+changes while the server is running, use the `recompile` command in IEx.
+
+## API
+
+The main API endpoint is `/tts`, which accepts JSON POST requests containing
+`voice_id` and `text` fields. An `x-api-key` HTTP header must also be set to
+the value specified in the `WATTS_API_KEY` environment variable.
+
+Example request, using `curl` and a local development instance of the app:
+
+    curl localhost:4000/tts \
+      --output voice.mp3 \
+      --header "x-api-key: your_api_key_here" \
+      --json '{"voice_id": "Matthew", "text": "<speak>Your text here.</speak>"}'
+
+Note to synthesize new (uncached) voice lines, the `WATTS_ENABLE_POLLY`
+environment variable must be `true`. **This incurs a cost per character of
+text**, so avoid large amounts of text or a large number of unique lines.


### PR DESCRIPTION
Adds some useful context and a ready-made `curl` command for testing to the README.

Also changes the env template to use a default value that actually works for `WATTS_BUCKET`. Not sure if this is preferable to just leaving it blank and making you think a bit about which bucket you want to use, but I think it is better than having a value that doesn't work.