### PR TITLE
Use Erlang-Alpine image for package handling in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM hexpm/erlang:${ERLANG_VERSION}-alpine-${ALPINE_VERSION}
 
 WORKDIR /root
 COPY --from=build /root/_build/prod/rel/watts /watts
+RUN apk add --no-cache dumb-init
 
 ENV TERM=xterm LANG=C.UTF-8 ERL_CRASH_DUMP_SECONDS=0
 


### PR DESCRIPTION
Use the erlang-alpine image for package handling in Docker. 

We still need to add `dumb-init` as a package, but cuts down on everything else. 