### PR TITLE
add dev deploy action

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,17 @@
+name: Deploy to dev
+
+on:
+  push:
+    branches: main
+  workflow_dispatch:
+
+jobs:
+  call-workflow:
+    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v2
+    with:
+      app-name: watts
+      environment: dev
+    secrets:
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
+      docker-repo: ${{ secrets.DOCKER_REPO }}
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -21,7 +21,7 @@ jobs:
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/install@v2
+      - uses: asdf-vm/actions/install@v4
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       # only install Hex/Rebar if we didn't hit the cache
       - if: steps.asdf-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
This adds an action to deploy to the new dev environment. I considered parameterizing the existing action rather than copying it, but it didn't seem possible to do that and also have it automatically deploy _both_ `dev` and `staging` on push to main, which I think is the desired behavior in this case.