### PR TITLE
fix: prevent SignatureDoesNotMatch for S3 PUT ops

### DIFF
--- a/lib/web_api.ex
+++ b/lib/web_api.ex
@@ -70,7 +70,7 @@ defmodule WebApi do
                     "pcm" -> "audio/pcm"
                     _ -> "application/octet-stream"
                   end,
-                meta: [{:text, text}]
+                meta: [{:text, Regex.replace(~r/[[:cntrl:]]/, text, "")}]
               )
               |> @ex_aws.request()
 


### PR DESCRIPTION


**Asana Task:** [Bug: PA Messages with SSML readout markup](https://app.asana.com/1/15492006741476/project/1213833239363217/task/1214455139781074?focus=true)

### Summary

Remove control characters from the `meta` header that is sent to S3 when placing audio files in S3. Prior to this commit, the `text` contents were being placed directly in `meta`, potentially containing control characters. Control characters, when placed in HTTP headers, can cause undesired results - for instance, newline characters can mark the end of a header line. This in turn can cause headers to be read improperly, and the AWS SDK to throw an error where the signature of the object cannot be properly calculated.

Prior to this change, text input such as "<speak>hello\n\nworld</speak>" would result in the following error:

```
<Error>
  <Code>SignatureDoesNotMatch</Code>
  <Message>
    The request signature we calculated does not match the signature you
    provided. Check your key and signing method.
  </Message>
  <!-- Elided -->
</Error>
```

### Notes for Reviewers

This appears to seldom happen ([splunk](https://mbta.splunkcloud.com/en-US/app/search/search?earliest=-30d%40d&latest=now&q=search%20index%3D%22watts-prod%22%20%22no%20match%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&sid=1780324149.159675)), but can in either of the following cases:
1. A Screenplay user with permissions to create PA messages creates one with newlines in the text field
2. Canned messages (e.g. those for bicycles/backpacks) that are hard coded with English and Spanish messages are [separated by newlines](https://github.com/mbta/screenplay/blob/c2e961f1f6a47e177829450399cb9fdd20fc247b/assets/static/static_templates.json#L30) for the presentation of the messages in Screenplay.

