### PR TITLE
chore: add github actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: "monday"
+    time: "10:00"
+  cooldown:
+    default-days: 7
+  open-pull-requests-limit: 5
 - package-ecosystem: mix
   directory: "/"
   schedule:


### PR DESCRIPTION


**Asana Task:** [title](url)

### Summary

Update dependabot configuration to update github actions. Prior to this commit, actions in this repo were logging deprecation warnings for Node 20-based actions:
```
call-workflow / Deploy main to staging
Node.js 20 actions are deprecated. The following actions are running on
Node.js 20 and may not work as expected: actions/checkout@v2.
```

### Notes for Reviewers

Noticed this when https://github.com/mbta/watts/pull/79 was deploying