### PR TITLE
fix: prevent SignatureDoesNotMatch for S3 PUT ops (pt 2)

### DIFF
--- a/lib/web_api.ex
+++ b/lib/web_api.ex
@@ -36,7 +36,7 @@ defmodule WebApi do
         {:ok, _} =
           ExAws.S3.put_object_copy(bucket, key, bucket, key,
             metadata_directive: :REPLACE,
-            meta: [{:text, text}]
+            meta: [{:text, remove_control_characters(text)}]
           )
           |> @ex_aws.request()
 
@@ -70,7 +70,7 @@ defmodule WebApi do
                     "pcm" -> "audio/pcm"
                     _ -> "application/octet-stream"
                   end,
-                meta: [{:text, Regex.replace(~r/[[:cntrl:]]/, text, "")}]
+                meta: [{:text, remove_control_characters(text)}]
               )
               |> @ex_aws.request()
 
@@ -103,5 +103,9 @@ defmodule WebApi do
     else
       conn
     end
+  end
+
+  defp remove_control_characters(text) do
+    Regex.replace(~r/[[:cntrl:]]/, text, "")
   end
 end


### PR DESCRIPTION


**Asana Task:** [Bug: PA Messages with SSML readout markup](https://app.asana.com/1/15492006741476/project/1213833239363217/task/1214455139781074?focus=true)


### Summary
This commit is a follow up to 691ab31e040928a4095c7c1b8c4ef1cf0481eb20, updating one additional usage of `text` as a header value that was missed previously. The removal of control characters is extracted to a function.

Control characters, when placed in HTTP headers, can cause undesired results - for instance, newline characters can mark the end of a header line. This in turn can cause headers to be read improperly, and the AWS SDK to throw an error where the signature of the object cannot be properly calculated.