### PR TITLE
ci: replace mbta/actions/reshim-asdf

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -41,10 +41,15 @@ jobs:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
-      - uses: mbta/actions/reshim-asdf@v2
-      # The asdf job should have prepared the cache. exit if it didn't for some reason
-      - run: exit 1
+      - name: Exit if ASDF cache isn't setup
+        run: exit 1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
+      - name: Setup ASDF environment
+        uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
+        with:
+          skip_install: true
+      - name: Reshim ASDF
+        run: asdf reshim
       - name: Restore dependencies cache
         id: deps-cache
         uses: actions/cache@v6.1.0


### PR DESCRIPTION


**Asana Task:** N/A

### Summary
Replace `mbta/actions/reshim-asdf` with `asdf-vm/actions/setup`. In the v2.20 release of the former, commit https://github.com/mbta/actions/commit/3579cb7ca08e2f13da2b49aee882d0d219d553f6 marked the `reshim-asdf` action as deprecated. A recent Dependabot update attempted to bump this action's version to v2.21 - while the update would succeed otherwise, replace the action now while it's on top of mind.