### PR TITLE
add zizmor to the repo

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -3,12 +3,16 @@ on:
   pull_request:
     types: [opened, edited]
 
+permissions: {}
+
 jobs:
   asana:
-    uses: mbta/workflows/.github/workflows/asana.yml@v5
+    uses: mbta/workflows/.github/workflows/asana.yml@c76e5ccd9556fbea52bc41548f7ceed5985ad775 # v5.1.0
     with:
       attach-pr: true
       trigger-phrase: "\\*\\*Asana Task:\\*\\*"
+    permissions:
+      pull-requests: read # Needed to read Asana ticket info from PR description
     secrets:
       asana-token: ${{ secrets.ASANA_SECRET_FOR_INSURIFY_ACTION }}
       github-secret: ${{ secrets.ASANA_GITHUB_INTEGRATION_SECRET }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,12 +5,18 @@ on:
     branches: main
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   call-workflow:
-    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v5
+    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@c76e5ccd9556fbea52bc41548f7ceed5985ad775 # v5.1.0
     with:
       app-name: watts
       environment: dev
+    permissions: {
+      contents: read, # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
+    }
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -13,10 +13,9 @@ jobs:
     with:
       app-name: watts
       environment: dev
-    permissions: {
-      contents: read, # Needed to check out the repository
+    permissions:
+      contents: read # Needed to check out the repository
       id-token: write # Needed to authenticate against AWS
-    }
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,6 +2,8 @@ name: Elixir CI
 
 on: [pull_request]
 
+permissions: {}
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -12,16 +14,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/install@v4
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       # only install Hex/Rebar if we didn't hit the cache
       - if: steps.asdf-cache.outputs.cache-hit != 'true'
@@ -34,9 +38,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: asdf
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: ASDF cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
@@ -52,7 +58,7 @@ jobs:
         run: asdf reshim
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -66,4 +72,4 @@ jobs:
         run: mix format --check-formatted
       - name: Run tests
         run: mix test
-      - uses: mbta/actions/dialyzer@v2.24
+      - uses: mbta/actions/dialyzer@788f8e264e9ebb1b76b927c89e6466d5a162be80 # v2.24

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -3,12 +3,18 @@ name: Deploy to prod
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   call-workflow:
-    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v5
+    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@c76e5ccd9556fbea52bc41548f7ceed5985ad775 # v5.1.0
     with:
       app-name: watts
       environment: prod
+    permissions: {
+      contents: read, # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
+    }
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -11,10 +11,9 @@ jobs:
     with:
       app-name: watts
       environment: prod
-    permissions: {
-      contents: read, # Needed to check out the repository
+    permissions:
+      contents: read # Needed to check out the repository
       id-token: write # Needed to authenticate against AWS
-    }
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,12 +5,18 @@ on:
     branches: main
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   call-workflow:
-    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v5
+    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@c76e5ccd9556fbea52bc41548f7ceed5985ad775 # v5.1.0
     with:
       app-name: watts
       environment: staging
+    permissions: {
+      contents: read, # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
+    }
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,10 +13,9 @@ jobs:
     with:
       app-name: watts
       environment: staging
-    permissions: {
-      contents: read, # Needed to check out the repository
+    permissions:
+      contents: read # Needed to check out the repository
       id-token: write # Needed to authenticate against AWS
-    }
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Check
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    paths:
+      - '.github/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          advanced-security: false
+          persona: auditor


### PR DESCRIPTION


**Asana Task:** [Add Zizmor to Watts](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1216719907405009?focus=true)

### Summary

This commit adds zizmor to the repo. Doing so entails to components:
1. Adding a new workflow to run zizmor when workflow files are edited
2. Updating existing workflows to be compliant with the pedantic persona provided by zizmor

For this repository, the latter consisted of:
1. Pinning actions used. Most actions were up to date already, making this action largely a no-op. Version comment strings have been updated to ensure they do not use major version only tags (e.g. `v5`), as these can cause issues should the tag move to a new version.
2. Updating permissions so actions use have the least amount of permission when running